### PR TITLE
Ensure cushionUse category visibility

### DIFF
--- a/public/js/tag-manager.js
+++ b/public/js/tag-manager.js
@@ -235,7 +235,12 @@ function getVisibleCategories(selections) {
     const visibleCategories = ['furnitureType', 'viewType'];
     
     // Check each category to see if its condition is met
-    for (const categoryId of window.TAG_CATEGORY_ORDER.slice(2)) { // Skip the first two (always visible)
+    for (const categoryId of window.TAG_CATEGORY_ORDER) {
+        // Skip the two base categories which are always visible
+        if (categoryId === 'furnitureType' || categoryId === 'viewType') {
+            continue;
+        }
+
         const category = window.TAG_MODEL[categoryId];
         if (!category) continue; // Should not happen if TAG_MODEL and TAG_CATEGORY_ORDER are in sync
 


### PR DESCRIPTION
## Summary
- iterate over all categories in `getVisibleCategories` and skip `furnitureType` and `viewType` by name

## Testing
- `node public/js/tag-manager.js` (via node script) to confirm cushionUse appears when furnitureType includes `cushionOnly`
- `npm test` *(fails: Test Suites: 1 failed, 3 passed, 4 total; Tests: 4 failed, 59 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689f75996bf88331868c8a5059c93f31